### PR TITLE
Add offset for productsByTagId and tags queries

### DIFF
--- a/src/schemas/productsByTagId.graphql
+++ b/src/schemas/productsByTagId.graphql
@@ -67,5 +67,8 @@ extend type Query {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
   ): TagProductConnection!
 }

--- a/src/schemas/tags.graphql
+++ b/src/schemas/tags.graphql
@@ -161,6 +161,9 @@ extend type Query {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
 

--- a/src/schemas/tags.graphql
+++ b/src/schemas/tags.graphql
@@ -16,6 +16,9 @@ extend type CatalogProduct {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
 
@@ -45,6 +48,9 @@ extend type Shop {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
 
@@ -67,6 +73,9 @@ extend type Tag {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
 
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Issue: https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for `productsByTagId`, and `tags` queries
