### PR TITLE
feat: Can filter products by tag query by titles or id

### DIFF
--- a/src/resolvers/Query/productsByTagId.js
+++ b/src/resolvers/Query/productsByTagId.js
@@ -9,6 +9,7 @@ import { decodeShopOpaqueId, decodeTagOpaqueId } from "../../xforms/id.js";
  * @param {Object} [params] - an object of all arguments that were sent by the client
  * @param {String} [params.shopId] - Shop id
  * @param {String} [params.tagId] - Tag id
+ * @param {String} [params.query] - Query string
  * @param {Object} context - an object containing the per-request state
  * @returns {Promise<Array<Object>>} TagProducts Connection
  */
@@ -20,7 +21,8 @@ export default async function productsByTagId(_, params, context) {
     last,
     shopId: opaqueShopId,
     sortOrder,
-    tagId: opaqueTagId
+    tagId: opaqueTagId,
+    query
   } = params;
 
   const shopId = decodeShopOpaqueId(opaqueShopId);
@@ -35,6 +37,7 @@ export default async function productsByTagId(_, params, context) {
       sortOrder
     },
     shopId,
-    tagId
+    tagId,
+    query
   });
 }

--- a/src/schemas/productsByTagId.graphql
+++ b/src/schemas/productsByTagId.graphql
@@ -56,6 +56,9 @@ extend type Query {
     "The tag ID"
     tagId: ID!,
 
+    "Regex match query string, for product title"
+    query: String,
+
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
     after: ConnectionCursor,
 


### PR DESCRIPTION
Adds an _optional_ new `query` param, which accepts a string/regex and can be used to filter the list of products in a tag by its titles/id.

This query is used in the Operator Panel where it currently just dumps out one unfiltered paginated list. This PR is in conjunction to a filter input text field added to the Operator Panel to allow them to filter the list by typing parts of the products title or ID.

No breaking changes.

Uses code referenced from https://github.com/reactioncommerce/api-plugin-products/blob/trunk/src/utils/applyProductFilters.js#L98