### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default async function register(app) {
           [{ name: 1 }, { name: "c2_name" }],
           [{ relatedTagIds: 1 }, { name: "c2_relatedTagIds" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
-          [{ slug: 1 }, { unique: true }]
+          [{ slug: 1, shopId: 1 }, { unique: true }]
         ]
       }
     },


### PR DESCRIPTION
fix: slugs should be unique for the same shopId

Resolves #6314 
Impact: **major**
Type: **bugfix**

## Issue
https://github.com/reactioncommerce/reaction/issues/6314

## Solution
Adding a shopId to the unique index will check only for the combination of slug-shopId to be unique.

## Testing

  1.  Start Reaction Development Platform
  2. Log in to reaction-admin
  3.  Create a shop
  4.   Create a tag with name 'food'
  5.  Create one more shop
  6.  Create a tag with name 'food' in new shop

Expected result: Tag 'food' can be created since there are no more tags with name 'food' in this shop
