### PR TITLE
chore: add integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,23 @@ jobs:
 
       - run: npm run lint
 
+  test-integration:
+    docker:
+      - image: circleci/node:14.11.0-stretch
+      # Integration tests need MongoDB server running and accessible on port 27017
+      - image: circleci/mongo:4.2.0
+        command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
+        ports:
+          - "27017:27017"
+    steps:
+      - checkout
+      - run:
+          name: Run Integration Tests
+          environment:
+            MONGO_URL: mongodb://localhost:27017/test
+            MONGO_USE_UNIFIED_TOPOLOGY: false
+          command: npx --quiet --package @reactioncommerce/ci-scripts@1.12.2 run-integration-tests
+
   test:
     docker:
       - image: node:12.14.1
@@ -75,11 +92,15 @@ workflows:
       - test:
           requires:
             - build
+      - test-integration:
+          requires:
+            - build
       - deploy:
           context: reaction-publish-semantic-release
           requires:
             - lint
             - test
+            - test-integration
           filters:
             branches:
               only: trunk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     dependencies:
       pre:
@@ -20,7 +20,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -50,9 +50,9 @@ jobs:
 
   test-integration:
     docker:
-      - image: circleci/node:14.11.0-stretch
+      - image: circleci/node:14.18.1-stretch
       # Integration tests need MongoDB server running and accessible on port 27017
-      - image: circleci/mongo:4.0.0
+      - image: circleci/mongo:4.2.0
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
@@ -70,7 +70,7 @@ jobs:
 
   test:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,10 @@ jobs:
           environment:
             MONGO_URL: mongodb://localhost:27017/test
             MONGO_USE_UNIFIED_TOPOLOGY: false
-          command: npx --quiet --package @reactioncommerce/ci-scripts@1.12.2 run-integration-tests
+          command: |
+            sudo apt-get install -y mongodb
+            mongo --eval "rs.initiate()"
+            npx --quiet --package @reactioncommerce/ci-scripts@1.12.2 run-integration-tests
 
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     docker:
       - image: circleci/node:14.11.0-stretch
       # Integration tests need MongoDB server running and accessible on port 27017
-      - image: circleci/mongo:4.2.0
+      - image: circleci/mongo:4.0.0
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
@@ -63,10 +63,7 @@ jobs:
           environment:
             MONGO_URL: mongodb://localhost:27017/test
             MONGO_USE_UNIFIED_TOPOLOGY: false
-          command: |
-            sudo apt-get install -y mongodb
-            mongo --eval "rs.initiate()"
-            npx --quiet --package @reactioncommerce/ci-scripts@1.12.2 run-integration-tests
+          command: npx --quiet --package @reactioncommerce/ci-scripts@1.12.2 run-integration-tests
 
   test:
     docker:


### PR DESCRIPTION
## Issue
Currently there are no integration tests to check a plugin update with the reaction version

## Solution
This PR adds a circle CI step that runs the integration tests on the plugin.

## Breaking changes
None expected

## Testing
1. Go to the CircleCI jobs, in the logs you can see the integration tests being run.